### PR TITLE
Update repository URL to Github

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@bitbucket.org:2dotstwice/culudb-websocket-server.git"
+    "url": "git@github.com:cultuurnet/udb3-websocket-server.git"
   },
   "author": "",
   "license": "ISC"


### PR DESCRIPTION
As the Github version of this repository appears to be the
canonical one (newer commits), it probably makes sense to
update the Composer metadata to reflect this.
